### PR TITLE
update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,10 +26,10 @@
   "dependencies": {
     "passport-strategy": "*",
     "xml2js": "~0.4.1",
-    "xml-crypto": "0.8.4",
-    "xmldom": "~0.1.19",
-    "xml-encryption": "~1.2.4",
-    "xpath": "0.0.5",
-    "passport": "^0.3.x"
+    "xml-crypto": "^2.1.3",
+    "xmldom": "~0.6.0",
+    "xml-encryption": "^2.0.0",
+    "xpath": "0.0.32",
+    "passport": "^0"
   }
 }


### PR DESCRIPTION
Update xml-encryption and other dependencies

Older version of xml-encryption brings in node-forge@0.x which has following vulnerabilities

```
[CVE-2020-7720](http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2020-7720):
The package node-forge before 0.10.0 is vulnerable to Prototype Pollution via the util.setPath function. Note: Version 0.10.0 is a breaking change removing the vulnerable functions.
```

```
[CVE-2022-0122](https://nvd.nist.gov/vuln/detail/CVE-2022-0122):
The package node-forge is vulnerable to URL Redirection to Untrusted Site
```