### PR TITLE
chore: update xmldom dependency

### DIFF
--- a/lib/decryptSAML.js
+++ b/lib/decryptSAML.js
@@ -3,7 +3,7 @@
  */
 'use strict';
 var crypto = require('crypto');
-var xmldom = require('xmldom');
+var xmldom = require('@xmldom/xmldom');
 var xmlencryption = require('xml-encryption');
 var xpath  = require('xpath');
 

--- a/lib/saml.js
+++ b/lib/saml.js
@@ -3,7 +3,7 @@ var xml2js = require('xml2js');
 var xmlCrypto = require('xml-crypto');
 var decryptSAML = require('./decryptSAML');
 var crypto = require('crypto');
-var xmldom = require('xmldom');
+var xmldom = require('@xmldom/xmldom');
 var querystring = require('querystring');
 
 var SAML = function (options) {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "passport-strategy": "*",
     "xml2js": "~0.4.1",
     "xml-crypto": "^2.1.3",
-    "xmldom": "~0.6.0",
+    "@xmldom/xmldom": "~0.8.6",
     "xml-encryption": "^2.0.0",
     "xpath": "0.0.32",
     "passport": "^0"


### PR DESCRIPTION
update xmldom dependency, as xmldom@0.6.0 is having the below vulnerability 
```
https://nvd.nist.gov/vuln/detail/CVE-2022-37616
A prototype pollution vulnerability exists in the function copy in dom.js in the xmldom (published as @xmldom/xmldom) package before 0.8.3 for Node.js via the p variable. NOTE: the vendor states "we are in the process of marking this report as invalid"; however, some third parties takes the position that "A prototype injection/Prototype pollution is not just when global objects are polluted with recursive merge or deep cloning but also when a target object is polluted."


```