### PR TITLE
fix: add error handling when validating saml response

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -22,6 +22,20 @@ function Strategy (options, verify) {
 
 util.inherits(Strategy, passport.Strategy);
 
+/**
+ * 
+ * NOTE: https://github.com/jaredhanson/passport-strategy#augmented-methods
+ * 
+ * passport-strategy provides augmented helper methods to assist in 
+ *    success / failure handling within the authenticate() method.
+ * 
+ * .success(user, info)
+ * .fail(challenge, status)
+ * .redirect(url, status)
+ * .pass()
+ * .error(err)
+ */
+
 Strategy.prototype.authenticate = function (req, options) {
   var self = this;
   if (req.body && req.body.SAMLResponse) {
@@ -59,7 +73,9 @@ Strategy.prototype.authenticate = function (req, options) {
       self._verify(profile, verified);
     });
     }catch(err){
-      // Error Handling
+      // This could happen for various reasons, but often means 
+      // the saml response / assertion is not encrypted
+      return self.error(err);
     }
   } else {
     // Initiate new SAML authentication request


### PR DESCRIPTION
- Add missing error handling when validating the SAML response. We noticed this when saml assertion was not encrypted which would lead to a hanging request.